### PR TITLE
Add Option for Dynamic Chart Legend Position

### DIFF
--- a/src/PhpWord/Style/Chart.php
+++ b/src/PhpWord/Style/Chart.php
@@ -308,6 +308,7 @@ class Chart extends AbstractStyle
      * "b" - bottom of chart
      * "t" - top of chart
      * "l" - left of chart
+     * "tr" - top right of chart
      *
      * default: right
      *

--- a/src/PhpWord/Style/Chart.php
+++ b/src/PhpWord/Style/Chart.php
@@ -67,6 +67,13 @@ class Chart extends AbstractStyle
     private $showLegend = false;
 
     /**
+     * Chart legend Position. 
+     *
+     * @var string
+     */
+    private $legendPosition = 'r';
+
+    /**
      * A list of display options for data labels
      *
      * @var array
@@ -281,6 +288,34 @@ class Chart extends AbstractStyle
     public function setShowLegend($value = false)
     {
         $this->showLegend = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get chart legend position
+     *
+     * @return string
+     */
+    public function getLegendPosition()
+    {
+        return $this->legendPosition;
+    }
+
+    /**
+     * Set chart legend position. choices:
+     * "r" - right of chart
+     * "b" - bottom of chart
+     * "t" - top of chart
+     * "l" - left of chart
+     *
+     * default: right
+     *
+     * @param bool $value
+     */
+    public function setLegendPosition($value = 'r')
+    {
+        $this->legendPosition = $value;
 
         return $this;
     }

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -131,6 +131,7 @@ class Chart extends AbstractPart
 
         $title = $style->getTitle();
         $showLegend = $style->isShowLegend();
+        $legendPosition = $style->getLegendPosition();
 
         //Chart title
         if ($title) {
@@ -154,7 +155,7 @@ class Chart extends AbstractPart
 
         //Chart legend
         if ($showLegend) {
-            $xmlWriter->writeRaw('<c:legend><c:legendPos val="r"/></c:legend>');
+            $xmlWriter->writeRaw('<c:legend><c:legendPos val="'.$legendPosition.'"/></c:legend>');
         }
 
         $xmlWriter->startElement('c:plotArea');


### PR DESCRIPTION
### Description

Currently thechart legend position cannot be altered via an option. This release fixes that by adding in an option in getStyle to set the legend position. It's using the ISO standards for adding it.

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
